### PR TITLE
token: Refactor payload generation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!   * Retrieving a Specific RRset
 //!   * Modifying an RRset
 //!   * Deleting an RRset
-//! 
+//!
 //! * Manage Tokens
 //!   * Create a token
 //!   * Modify a token
@@ -111,11 +111,11 @@
 //!
 //! [error]: enum.Error.html
 
+use const_format::concatcp;
 use log::debug;
 use reqwest::{header, Response, StatusCode};
 use thiserror::Error;
 use tokio::time::{sleep, Duration};
-use const_format::concatcp;
 
 pub mod account;
 pub mod domain;
@@ -169,7 +169,7 @@ pub struct Client {
     /// Maximum number of retries
     max_retries: usize,
     /// Whether this client has been logged in before
-    logged_in: bool
+    logged_in: bool,
 }
 
 impl Client {
@@ -192,7 +192,7 @@ impl Client {
             retry: true,
             max_wait_retry: 60,
             max_retries: 3,
-            logged_in: logged_in.unwrap_or_default()
+            logged_in: logged_in.unwrap_or_default(),
         })
     }
 
@@ -256,9 +256,7 @@ impl Client {
         if !self.logged_in {
             return Err(Error::CannotLogout);
         }
-        let response = self
-            .post("/auth/logout/", None)
-            .await?;
+        let response = self.post("/auth/logout/", None).await?;
         match response.status() {
             StatusCode::NO_CONTENT => Ok(()),
             _ => Err(Error::UnexpectedStatusCode(
@@ -270,32 +268,32 @@ impl Client {
 
     /// Sets whether retries are enabled.
     pub fn set_retry(&mut self, retry: bool) {
-       self.retry = retry;
+        self.retry = retry;
     }
 
     /// Returns whether retries are enabled.
     pub fn get_retry(&self) -> &bool {
-       &self.retry
+        &self.retry
     }
 
     /// Sets the maximum wait time for a single retry
     pub fn set_max_wait_retry(&mut self, max_wait_retry: u64) {
-       self.max_wait_retry = max_wait_retry;
+        self.max_wait_retry = max_wait_retry;
     }
 
     /// Returns the maximum wait time for a single retry
     pub fn get_max_wait_retry(&self) -> &u64 {
-       &self.max_wait_retry
+        &self.max_wait_retry
     }
 
     /// Sets the maximum number of retries
     pub fn set_max_retries(&mut self, max_retries: usize) {
-       self.max_retries = max_retries;
+        self.max_retries = max_retries;
     }
 
     /// Returns the maximum number of retries
     pub fn get_max_retries(&self) -> &usize {
-       &self.max_retries
+        &self.max_retries
     }
 
     /// Sends the request and processes the response.

--- a/src/rrset.rs
+++ b/src/rrset.rs
@@ -110,7 +110,11 @@ impl<'a> RrsetClient<'a> {
     /// see [General errors][general_errors]
     ///
     /// [general_errors]: ../index.html#general-errors-for-all-clients
-    pub async fn get_rrsets_by_type(&self, domain: &str, r#type: &str) -> Result<Vec<ResourceRecordSet>, Error> {
+    pub async fn get_rrsets_by_type(
+        &self,
+        domain: &str,
+        r#type: &str,
+    ) -> Result<Vec<ResourceRecordSet>, Error> {
         let response = self
             .client
             .get(format!("/domains/{domain}/rrsets/?type={}", r#type).as_str())
@@ -135,7 +139,11 @@ impl<'a> RrsetClient<'a> {
     /// see [General errors][general_errors]
     ///
     /// [general_errors]: ../index.html#general-errors-for-all-clients
-    pub async fn get_rrsets_by_subname(&self, domain: &str, subname: &str) -> Result<Vec<ResourceRecordSet>, Error> {
+    pub async fn get_rrsets_by_subname(
+        &self,
+        domain: &str,
+        subname: &str,
+    ) -> Result<Vec<ResourceRecordSet>, Error> {
         let response = self
             .client
             .get(format!("/domains/{domain}/rrsets/?subname={subname}").as_str())

--- a/src/token.rs
+++ b/src/token.rs
@@ -60,29 +60,13 @@ impl<'a> TokenClient<'a> {
         max_age: Option<String>,
         max_unused_period: Option<String>,
     ) -> Result<Token, Error> {
-        // Construct payload
-        let mut payload_map = Map::new();
-        if let Some(name) = name {
-            payload_map.insert("name".to_string(), Value::String(name));
-        }
-        if let Some(allowed_subnets) = allowed_subnets {
-            payload_map.insert("allowed_subnets".to_string(), Value::from(allowed_subnets));
-        }
-        if let Some(perm_manage_tokens) = perm_manage_tokens {
-            payload_map.insert(
-                "perm_manage_tokens".to_string(),
-                Value::Bool(perm_manage_tokens),
-            );
-        }
-        if let Some(max_age) = max_age {
-            payload_map.insert("max_age".to_string(), Value::String(max_age));
-        }
-        if let Some(max_unused_period) = max_unused_period {
-            payload_map.insert(
-                "max_unused_period".to_string(),
-                Value::String(max_unused_period),
-            );
-        }
+        let payload_map = construct_token_payload(
+            name,
+            allowed_subnets,
+            perm_manage_tokens,
+            max_age,
+            max_unused_period,
+        );
         let payload = Some(serde_json::to_string(&payload_map).unwrap());
         // Send create token request
         let response = self.client.post("/auth/tokens/", payload).await?;
@@ -185,29 +169,13 @@ impl<'a> TokenClient<'a> {
         max_age: Option<String>,
         max_unused_period: Option<String>,
     ) -> Result<Token, Error> {
-        // Construct payload
-        let mut payload_map = Map::new();
-        if let Some(name) = name {
-            payload_map.insert("name".to_string(), Value::String(name));
-        }
-        if let Some(allowed_subnets) = allowed_subnets {
-            payload_map.insert("allowed_subnets".to_string(), Value::from(allowed_subnets));
-        }
-        if let Some(perm_manage_tokens) = perm_manage_tokens {
-            payload_map.insert(
-                "perm_manage_tokens".to_string(),
-                Value::Bool(perm_manage_tokens),
-            );
-        }
-        if let Some(max_age) = max_age {
-            payload_map.insert("max_age".to_string(), Value::String(max_age));
-        }
-        if let Some(max_unused_period) = max_unused_period {
-            payload_map.insert(
-                "max_unused_period".to_string(),
-                Value::String(max_unused_period),
-            );
-        }
+        let payload_map = construct_token_payload(
+            name,
+            allowed_subnets,
+            perm_manage_tokens,
+            max_age,
+            max_unused_period,
+        );
         let payload = serde_json::to_string(&payload_map).unwrap();
         let response = self
             .client
@@ -241,27 +209,7 @@ impl<'a> TokenClient<'a> {
         r#type: Option<String>,
         perm_write: Option<bool>,
     ) -> Result<TokenPolicy, Error> {
-        // Construct payload
-        let mut payload_map = Map::new();
-        if let Some(domain) = domain {
-            payload_map.insert("domain".to_string(), Value::String(domain));
-        } else {
-            payload_map.insert("domain".to_string(), Value::Null);
-        }
-        if let Some(subname) = subname {
-            payload_map.insert("subname".to_string(), Value::String(subname));
-        } else {
-            payload_map.insert("subname".to_string(), Value::Null);
-        }
-        if let Some(r#type) = r#type {
-            payload_map.insert("type".to_string(), Value::String(r#type));
-        } else {
-            payload_map.insert("type".to_string(), Value::Null);
-        }
-        payload_map.insert(
-            "bool".to_string(),
-            Value::Bool(perm_write.unwrap_or_default()),
-        );
+        let payload_map = construct_policy_payload(domain, subname, r#type, perm_write);
         let payload = Some(serde_json::to_string(&payload_map).unwrap());
         let response = self
             .client
@@ -299,20 +247,7 @@ impl<'a> TokenClient<'a> {
         r#type: Option<String>,
         perm_write: Option<bool>,
     ) -> Result<TokenPolicy, Error> {
-        // Construct payload
-        let mut payload_map = Map::new();
-        if let Some(domain) = domain {
-            payload_map.insert("domain".to_string(), Value::String(domain));
-        }
-        if let Some(subname) = subname {
-            payload_map.insert("subname".to_string(), Value::String(subname));
-        }
-        if let Some(r#type) = r#type {
-            payload_map.insert("type".to_string(), Value::String(r#type));
-        }
-        if let Some(perm_write) = perm_write {
-            payload_map.insert("perm_write".to_string(), Value::Bool(perm_write));
-        }
+        let payload_map = construct_policy_payload(domain, subname, r#type, perm_write);
         let payload = serde_json::to_string(&payload_map).unwrap();
         let response = self
             .client
@@ -408,4 +343,58 @@ impl<'a> TokenClient<'a> {
             )),
         }
     }
+}
+
+// Construct token policy payload for CREATE and PATCH
+fn construct_policy_payload(
+    domain: Option<String>,
+    subname: Option<String>,
+    r#type: Option<String>,
+    perm_write: Option<bool>,
+) -> Map<String, Value> {
+    let mut payload_map = Map::new();
+    let domain = domain.map_or(Value::Null, Value::String);
+    let subname = subname.map_or(Value::Null, Value::String);
+    let r#type = r#type.map_or(Value::Null, Value::String);
+    payload_map.insert("domain".to_string(), domain);
+    payload_map.insert("subname".to_string(), subname);
+    payload_map.insert("type".to_string(), r#type);
+    payload_map.insert(
+        "perm_write".to_string(),
+        Value::Bool(perm_write.unwrap_or_default()),
+    );
+    payload_map
+}
+
+// Construct token payload for CREATE and PATCH
+fn construct_token_payload(
+    name: Option<String>,
+    allowed_subnets: Option<Vec<String>>,
+    perm_manage_tokens: Option<bool>,
+    max_age: Option<String>,
+    max_unused_period: Option<String>,
+) -> Map<String, Value> {
+    let mut payload_map = Map::new();
+    if let Some(name) = name {
+        payload_map.insert("name".to_string(), Value::String(name));
+    }
+    if let Some(allowed_subnets) = allowed_subnets {
+        payload_map.insert("allowed_subnets".to_string(), Value::from(allowed_subnets));
+    }
+    if let Some(perm_manage_tokens) = perm_manage_tokens {
+        payload_map.insert(
+            "perm_manage_tokens".to_string(),
+            Value::Bool(perm_manage_tokens),
+        );
+    }
+    if let Some(max_age) = max_age {
+        payload_map.insert("max_age".to_string(), Value::String(max_age));
+    }
+    if let Some(max_unused_period) = max_unused_period {
+        payload_map.insert(
+            "max_unused_period".to_string(),
+            Value::String(max_unused_period),
+        );
+    }
+    payload_map
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -326,11 +326,7 @@ impl<'a> TokenClient<'a> {
     /// see [General errors][general_errors]
     ///
     /// [general_errors]: ../index.html#general-errors-for-all-clients
-    pub async fn delete_policy(
-        &self,
-        token_id: &str,
-        policy_id: &str,
-    ) -> Result<(), Error> {
+    pub async fn delete_policy(&self, token_id: &str, policy_id: &str) -> Result<(), Error> {
         let response = self
             .client
             .delete(format!("/auth/tokens/{token_id}/policies/rrsets/{policy_id}/").as_str())


### PR DESCRIPTION
This also fixes a problem when creating a policy.
Instead of setting the `perm_write` key to a bool, a `bool` key was created with a boolean as value.
It was not possible to create a token with write permissions due to that typo.

Also run `cargo fmt`.